### PR TITLE
fix: derive CLI version from package metadata

### DIFF
--- a/fakenos/plugins/utils/cli.py
+++ b/fakenos/plugins/utils/cli.py
@@ -6,10 +6,11 @@ import argparse
 import logging
 import os
 import time
+from importlib.metadata import version
 
 from fakenos import FakeNOS
 
-__version__ = "1.0.0"
+__version__ = version("fakenos")
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Closes #4

Replace hardcoded `__version__ = "1.0.0"` in `fakenos/plugins/utils/cli.py` with `importlib.metadata.version("fakenos")` so the CLI version always matches `pyproject.toml`.

## Changes

| File | Change |
|------|--------|
| `fakenos/plugins/utils/cli.py` | `__version__ = "1.0.0"` → `__version__ = version("fakenos")` via `importlib.metadata` |

## Before / After

- Before: `FakeNOS, version 1.0.0` (hardcoded, out of sync with pyproject.toml `1.1.0`)
- After: `FakeNOS, version 1.1.0` (derived from package metadata, always in sync)

## Test plan

- [x] `uv run python -c "from fakenos.plugins.utils.cli import __version__; print(__version__)"` → `1.1.0`
- [x] `uv run pytest` — 257 passed
- [x] Reviewed by Codex and Gemini CLI — both LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)