### PR TITLE
fix: enable mikrotik_routeros platform with username matching (#29)

### DIFF
--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -44,7 +44,7 @@ The following list of platforms are supported by FakeNOS. All the platforms list
 - [juniper_junos](platforms/juniper_junos.md) ✅
 - [juniper_screenos](platforms/juniper_screenos.md) ✅
 - [linux](platforms/linux.md) ✅
-- [mikrotik_routeros](platforms/mikrotik_routeros.md) ❌[See issue](https://github.com/fakenos/fakenos/issues/9)
+- [mikrotik_routeros](platforms/mikrotik_routeros.md) ✅
 - [paloalto_panos](platforms/paloalto_panos.md) ✅
 - [ruckus_fastiron](platforms/ruckus_fastiron.md) ✅
 - [ubiquiti_edgerouter](platforms/ubiquiti_edgerouter.md) ✅

--- a/fakenos/core/nos.py
+++ b/fakenos/core/nos.py
@@ -238,7 +238,7 @@ class Nos:
         elif filename.endswith(".py"):
             self._from_module(filename)
 
-    def is_file_ending_correct(self, filename: str) -> None:
+    def is_file_ending_correct(self, filename: str) -> bool:
         """
         Method to check if file extension is correct and load NOS data.
         Correct types are: .yaml, .yml and .py

--- a/fakenos/core/nos.py
+++ b/fakenos/core/nos.py
@@ -46,7 +46,7 @@ available_platforms: list[str] = [
     "juniper_junos",
     "juniper_screenos",
     "linux",
-    # "mikrotik_routeros",
+    "mikrotik_routeros",
     "paloalto_panos",
     "ruckus_fastiron",
     "ubiquiti_edgerouter",

--- a/fakenos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
+++ b/fakenos/plugins/nos/platforms_yaml/mikrotik_routeros.yaml
@@ -1,13 +1,6 @@
 name: mikrotik_routeros
-initial_prompt: "{base_prompt}>"
-enable_prompt: "{base_prompt}#"
-config_prompt: "{base_prompt}(config)#"
+initial_prompt: "[admin@{base_prompt}] >"
 commands:
-  enable:
-    output: null
-    new_prompt: "{base_prompt}#"
-    help: enter enable mode
-    prompt: "{base_prompt}>"
   ip firewall filter print all without-paging:
     output: "Flags: X - disabled, I - invalid, D - dynamic \n 0    ;;; defconf: accept
       established,related,untracked\n      chain=input action=accept connection-state=established,related,untracked
@@ -42,17 +35,13 @@ commands:
       \  chain=input action=drop in-interface=all-ppp \n\n22    chain=input action=drop
       in-interface=all-ethernet log-prefix=\"\"\n"
     help: execute the command "ip firewall filter print all without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   system clock print:
     output: "                  time: 10:00:47\n                  date: jul/21/2023\n\
       \  time-zone-autodetect: yes\n        time-zone-name: Europe/Moscow\n      \
       \      gmt-offset: +03:00\n            dst-active: no"
     help: execute the command "system clock print"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ip route print terse:
     output: " 0 ADS  dst-address=::/0 gateway=pppoe-out1 gateway-status=pppoe-out1
       reachable distance=100 scope=30 target-scope=10 \n 1 ADC  dst-address=2a05:c100:7::/64
@@ -64,9 +53,7 @@ commands:
       \n 4   S  dst-address=fd79:f1d4:a400::/39 gateway=ether5 gateway-status=ether5
       unreachable distance=24 scope=30 target-scope=10 \n"
     help: execute the command "ip route print terse"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ip dhcp-server lease print without-paging:
     output: "Flags: X - disabled, R - radius, D - dynamic, B - blocked \n #   ADDRESS\
       \                                 MAC-ADDRESS       HOST-NAME              \
@@ -80,15 +67,11 @@ commands:
       \ 15                             waiting never                             \
       \      \n"
     help: execute the command "ip dhcp-server lease print without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   interface ethernet poe print without-paging:
     output: "bad command name po (line 1 column 7)\n"
     help: execute the command "interface ethernet poe print without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   interface ethernet print:
     output: "Flags: X - disabled, R - running, S - slave\n #    NAME     MTU MAC-ADDRESS\
       \       ARP             SWITCH\n 0    ether1  1500 12:34:56:78:90:AA enabled\
@@ -97,26 +80,20 @@ commands:
       12:34:56:78:90:AD enabled         switch1\n 4 R  ether5  1500 12:34:56:78:90:AE
       enabled         switch1\n"
     help: execute the command "interface ethernet print"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   system routerboard print:
     output: "       routerboard: yes\n        board-name: hEX PoE lite\n         \
       \    model: RouterBOARD 750UP r2\n     serial-number: 8B0208F4D5F9\n     firmware-type:
       qca9531L\n  factory-firmware: 3.41\n  current-firmware: 3.41\n  upgrade-firmware:
       6.48.6\n"
     help: execute the command "system routerboard print"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   user active print:
     output: "Flags: R - radius, M - by-romon\n #    WHEN                 NAME    \
       \   ADDRESS         VIA\n 0    jul/21/2023 09:38:39 user1      1.2.3.4     \
       \    ssh\n 1    jul/21/2023 11:00:32 user2      1.2.3.5         telnet\n"
     help: execute the command "user active print"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ip firewall address-list print terse:
     output: " 0   list=Eqinoxe address=185.48.253.0/27 creation-time=jan/01/2002 01:00:25
       \n 1   list=Eqinoxe address=185.48.254.0/28 creation-time=jan/01/2002 01:00:25
@@ -136,9 +113,7 @@ commands:
       timeout=4m52s \n15 list=snmp-monitoring-address-list address=85.14.167.234 creation-time=mar/01/2023
       13:59:33\n"
     help: execute the command "ip firewall address-list print terse"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   log print detail without-paging:
     output: " time=jul/19 14:27:01 topics=script,info message=\"Ping testA: Packets
       Sent = 18, Packets Loss = 10 % \"\n\n time=jul/19 16:27:01 topics=script,info
@@ -151,9 +126,7 @@ commands:
       message=\"lte1 link up\"\n\n time=jul/20 03:07:46 topics=dhcp,info message=\"\
       dhcp-client on lte1 got IP address 192.168.1.2\"\n"
     help: execute the command "log print detail without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ip firewall nat print all without-paging:
     output: "Flags: X - disabled, I - invalid, D - dynamic \n17:20:06 echo: system,error,critical
       login failure for user admin from 65.160.140.13 via ssh\n 0    ;;; dmz-1: masquerade\n\
@@ -168,9 +141,7 @@ commands:
       protocol=icmp src-address=0.0.0.0 out-interface-list=DMZ log=no log-prefix=\"\
       \" ipsec-policy=out,ipsec \n"
     help: execute the command "ip firewall nat print all without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   routing bgp peer print status without-paging:
     output: "Flags: X - disabled, E - established\n 0 E name=\"SRV-R1\" instance=default
       remote-address=1.2.3.4 remote-as=8491 tcp-md5-key=\"\" nexthop-choice=default
@@ -189,9 +160,7 @@ commands:
       withdrawn-received=84680 remote-hold-time=1m30s used-hold-time=1m30s used-keepalive-time=30s
       refresh-capability=yes as4-capability=yes state=established\n"
     help: execute the command "routing bgp peer print status without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ipv6 neighbor print without-paging:
     output: "Flags: R - router \n 0   address=ff02::5 interface=main mac-address=33:33:00:00:00:05
       status=\"noarp\" \n\n 1   address=ff02::1 interface=main mac-address=33:33:00:00:00:01
@@ -199,26 +168,20 @@ commands:
       status=\"stale\" \n\n 3   address=2a05:c100:1d::351c interface=bridge-lan status=\"\
       failed\"\n"
     help: execute the command "ipv6 neighbor print without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ip address print:
     output: "Flags: X - disabled, I - invalid, D - dynamic\n #   ADDRESS         \
       \   NETWORK         INTERFACE\n 0   10.156.1.229/30    10.156.1.228    ether4_CiscoPhone3\n
       1   10.152.1.229/30    10.152.1.228    ether5_KFCcisco\n 2   10.160.1.229/30\
       \    10.160.1.228    ether2_BOX\n 3 XI 10.100.3.200/27    10.100.3.192    bridge70\n"
     help: execute the command "ip address print"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   interface ethernet monitor name once:
     output: "                     name: ether30\n                    status: no-link\n\
       \          auto-negotiation: done\n               advertising: 10M-half,10M-full,100M-half,100M-full,1000M-half,1000M-full\n\
       \  link-partner-advertising:\n"
     help: execute the command "interface ethernet monitor name once"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   snmp community print without-paging:
     output: "17:20:06 echo: system,error,critical login failure for user admin from
       65.160.140.13 via ssh\nFlags: * - default, X - disabled \n #    NAME       \
@@ -230,9 +193,7 @@ commands:
       \                                                          none       yes  \
       \       no          \n"
     help: execute the command "snmp community print without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ip arp print without-paging:
     output: "Flags: X - disabled, I - invalid, H - DHCP, D - dynamic, P - published,
       C - complete \n #    ADDRESS         MAC-ADDRESS       INTERFACE           \
@@ -246,18 +207,14 @@ commands:
       \                                                                          \
       \      \n"
     help: execute the command "ip arp print without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ip address export verbose:
     output: "# jul/21/2023 09:42:42 by RouterOS 6.48.6\n# software id = 1234-ABCD\n
       #\n# model = RB750UPr2\n# serial number = AB12345CD789\n/ip address\nadd address=10.159.1.159/30
       disabled=no interface=ether2 network=10.159.1.158\nadd address=10.80.90.5/27
       comment=\"test comment\" disabled=yes interface=eth3_vlan1 network=10.80.90.0\n"
     help: execute the command "ip address export verbose"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   routing ospf neighbor print terse without-paging:
     output: " 0 instance=default router-id=1.2.3.4 address=1.2.3.58 interface=vlan1
       priority=128 dr-address=0.0.0.0 backup-dr-address=0.0.0.0 state=Full state-changes=5
@@ -266,9 +223,7 @@ commands:
       backup-dr-address=0.0.0.0 state=Full state-changes=5 ls-retransmits=0 ls-requests=0
       db-summaries=0\n"
     help: execute the command "routing ospf neighbor print terse without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   interface print terse without-paging:
     output: " 0 D   name=ether1 default-name=ether1 type=ether mtu=1500 actual-mtu=1500
       l2mtu=1598 max-l2mtu=2028 mac-address=12:34:56:78:90:AA last-link-up-time=aug/16/1970
@@ -292,9 +247,7 @@ commands:
       fast-path=yes last-link-down-time=sep/08/2023 01:07:00 last-link-up-time=sep/08/2023
       01:07:09 link-downs=7\n"
     help: execute the command "interface print terse without-paging"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"
   ping:
     output: "  SEQ HOST                                     SIZE TTL TIME  STATUS\n\
       \    0 8.8.8.8                                    56  64 157ms\n    1 8.8.8.8\
@@ -303,6 +256,4 @@ commands:
       \            56  64 65ms\n    sent=13 received=13 packet-loss=0% min-rtt=55ms
       avg-rtt=67ms max-rtt=157ms\n"
     help: execute the command "ping"
-    prompt:
-    - "{base_prompt}>"
-    - "{base_prompt}#"
+    prompt: "[admin@{base_prompt}] >"

--- a/fakenos/plugins/servers/ssh_server_paramiko.py
+++ b/fakenos/plugins/servers/ssh_server_paramiko.py
@@ -82,7 +82,7 @@ class ParamikoSshServerInterface(paramiko.ServerInterface):
         """
         This will allow the SSH server to provide a channel for the client
         to communicate over. By default, this will return
-        OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED, so  we have to override it
+        OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED, so we have to override it
         to return OPEN_SUCCEEDED when the kind of channel
         requested is "session".
         """


### PR DESCRIPTION
## Summary
- netmiko の `MikrotikRouterOsSSH` がユーザー名に `+ct511w4098h` を追加して SSH 認証するため、FakeNOS の厳密一致認証で失敗していた問題を修正
- YAML プロンプトを MikroTik 形式 (`[admin@hostname] >`) に変更し、netmiko の期待パターン (`\].*>`) と整合
- `_match_username()` で exact-match-first 戦略を採用し、`+` を含む正規ユーザー名の誤切り捨てを防止

## Changes
- `ssh_server_paramiko.py`: `_match_username()` 追加（exact match → `+` suffix fallback）
- `mikrotik_routeros.yaml`: プロンプトを MikroTik 形式に変更、enable/config モード削除
- `nos.py`: `mikrotik_routeros` のコメントアウト解除 + `is_file_ending_correct()` 戻り値型修正
- `docs/platforms/index.md`: ❌ → ✅
- `test_ssh_server_paramiko.py`: `ParamikoSshServerInterfaceUsernameMatchTest` 追加（15 テスト）

## Test plan
- [x] `uv run pytest tests/ -v --ignore=tests/core/test_docker.py` → 338 passed
- [x] `uv run pytest tests/plugins/test_ssh_server_paramiko.py -v` → 85 passed
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run ruff format --check .` → 40 files already formatted

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)